### PR TITLE
Add schema to rename default

### DIFF
--- a/alembic_postgresql_enum/operations/sync_enum_values.py
+++ b/alembic_postgresql_enum/operations/sync_enum_values.py
@@ -84,7 +84,7 @@ class SyncEnumValuesOp(alembic.operations.ops.MigrateOperation):
 
             if column_default is not None:
                 column_default = rename_default_if_required(column_default, enum_name,
-                                                            enum_values_to_rename)
+                                                            enum_values_to_rename, schema)
 
                 set_default(connection, schema, table_reference, column_default)
 

--- a/alembic_postgresql_enum/sql_commands/column_default.py
+++ b/alembic_postgresql_enum/sql_commands/column_default.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Union, List, Tuple
+from typing import TYPE_CHECKING, Optional, Union, List, Tuple
 
 import sqlalchemy
 
@@ -46,7 +46,8 @@ def set_default(connection: 'Connection',
 
 def rename_default_if_required(default_value: str,
                                enum_name: str,
-                               enum_values_to_rename: List[Tuple[str, str]]
+                               enum_values_to_rename: List[Tuple[str, str]],
+                               schema: Optional[str],
                                ) -> str:
     is_array = default_value.endswith("[]")
     # remove old type postfix
@@ -57,4 +58,6 @@ def rename_default_if_required(default_value: str,
         column_default_value = column_default_value.replace(f'"{old_value}"', f'"{new_value}"')
 
     suffix = "[]" if is_array else ""
+    if schema:
+        return f"{column_default_value}::{schema}.{enum_name}{suffix}"
     return f"{column_default_value}::{enum_name}{suffix}"

--- a/tests/sync_enum_values/test_rename_default_if_required.py
+++ b/tests/sync_enum_values/test_rename_default_if_required.py
@@ -1,31 +1,63 @@
 from alembic_postgresql_enum.sql_commands.column_default import rename_default_if_required
 
 
-def test_without_renames():
+def test_without_renames_no_schema():
     old_default_value = "'passive'::order_status_old"
 
-    assert (rename_default_if_required(old_default_value, 'order_status', [])
+    assert (rename_default_if_required(old_default_value, 'order_status', [], None)
             == "'passive'::order_status")
 
 
-def test_with_renames():
+def test_with_renames_no_schema():
     old_default_value = "'passive'::order_status_old"
 
     assert (rename_default_if_required(old_default_value, 'order_status', [
         ('passive', 'inactive')
-    ]) == "'inactive'::order_status")
+    ], None) == "'inactive'::order_status")
 
 
-def test_array_with_renames():
+def test_array_with_renames_no_schema():
     old_default_value = """'{"passive"}'::order_status_old"""
 
     assert (rename_default_if_required(old_default_value, 'order_status', [
         ('passive', 'inactive')
-    ]) == """'{"inactive"}'::order_status""")
+    ], None) == """'{"inactive"}'::order_status""")
 
 
-def test_array_default_value():
+def test_array_default_value_no_schema():
     old_default_value = """'{}'::order_status_old[]"""
 
-    assert (rename_default_if_required(old_default_value, 'order_status', [])
+    assert (rename_default_if_required(old_default_value, 'order_status', [], None)
             == """'{}'::order_status[]""")
+    
+
+# Tests with schema provided
+
+def test_without_renames_no_schema():
+    old_default_value = "'passive'::order_status_old"
+
+    assert (rename_default_if_required(old_default_value, 'order_status', [], None)
+            == "'passive'::order_status")
+
+
+def test_with_renames_with_schema():
+    old_default_value = "'passive'::test.order_status_old"
+
+    assert (rename_default_if_required(old_default_value, 'order_status', [
+        ('passive', 'inactive')
+    ], "test") == "'inactive'::order_status")
+
+
+def test_array_with_renames_with_schema():
+    old_default_value = """'{"passive"}'::test.order_status_old"""
+
+    assert (rename_default_if_required(old_default_value, 'order_status', [
+        ('passive', 'inactive')
+    ], "test") == """'{"inactive"}'::order_status""")
+
+
+def test_array_default_value_with_schema():
+    old_default_value = """'{}'::test.order_status_old[]"""
+
+    assert (rename_default_if_required(old_default_value, 'order_status', [], "test")
+            == """'{}'::test.order_status[]""")

--- a/tests/sync_enum_values/test_rename_default_if_required.py
+++ b/tests/sync_enum_values/test_rename_default_if_required.py
@@ -34,10 +34,10 @@ def test_array_default_value_no_schema():
 # Tests with schema provided
 ##################################################
 
-def test_without_renames_no_schema():
-    old_default_value = "'passive'::order_status_old"
+def test_without_renames_with_schema():
+    old_default_value = "'passive'::test.order_status_old"
 
-    assert (rename_default_if_required(old_default_value, 'order_status', [], None)
+    assert (rename_default_if_required(old_default_value, 'order_status', [], "test")
             == "'passive'::order_status")
 
 
@@ -46,7 +46,7 @@ def test_with_renames_with_schema():
 
     assert (rename_default_if_required(old_default_value, 'order_status', [
         ('passive', 'inactive')
-    ], "test") == "'inactive'::order_status")
+    ], "test") == "'inactive'::test.order_status")
 
 
 def test_array_with_renames_with_schema():
@@ -54,7 +54,7 @@ def test_array_with_renames_with_schema():
 
     assert (rename_default_if_required(old_default_value, 'order_status', [
         ('passive', 'inactive')
-    ], "test") == """'{"inactive"}'::order_status""")
+    ], "test") == """'{"inactive"}'::test.order_status""")
 
 
 def test_array_default_value_with_schema():

--- a/tests/sync_enum_values/test_rename_default_if_required.py
+++ b/tests/sync_enum_values/test_rename_default_if_required.py
@@ -30,8 +30,9 @@ def test_array_default_value_no_schema():
     assert (rename_default_if_required(old_default_value, 'order_status', [], None)
             == """'{}'::order_status[]""")
     
-
+##################################################
 # Tests with schema provided
+##################################################
 
 def test_without_renames_no_schema():
     old_default_value = "'passive'::order_status_old"

--- a/tests/sync_enum_values/test_rename_default_if_required.py
+++ b/tests/sync_enum_values/test_rename_default_if_required.py
@@ -38,7 +38,7 @@ def test_without_renames_with_schema():
     old_default_value = "'passive'::test.order_status_old"
 
     assert (rename_default_if_required(old_default_value, 'order_status', [], "test")
-            == "'passive'::order_status")
+            == "'passive'::test.order_status")
 
 
 def test_with_renames_with_schema():


### PR DESCRIPTION
Fixes #53 

### Description
This change modifies the `rename_default_if_required` function to also allow for the passing of a schema. This allows for the setting of a default value on columns to be able to include enums from the schema. 

Tests were modified to show the with schema provided, and without. 

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**