### PR TITLE
Schema-qualify comparison functions and operators in sync_enum_values

### DIFF
--- a/alembic_postgresql_enum/operations/sync_enum_values.py
+++ b/alembic_postgresql_enum/operations/sync_enum_values.py
@@ -97,7 +97,7 @@ class SyncEnumValuesOp(alembic.operations.ops.MigrateOperation):
         rename_type(connection, enum_type_name, temporary_enum_name)
         create_type(connection, enum_type_name, new_values)
 
-        create_comparison_operators(connection, enum_type_name, temporary_enum_type_name, enum_values_to_rename)
+        create_comparison_operators(connection, enum_schema, enum_type_name, temporary_enum_type_name, enum_values_to_rename)
 
         drop_indexes(connection, indexes_to_recreate)
 
@@ -123,7 +123,7 @@ class SyncEnumValuesOp(alembic.operations.ops.MigrateOperation):
 
                 set_default(connection, table_reference, column_default)
 
-        drop_comparison_operators(connection, enum_type_name, temporary_enum_type_name)
+        drop_comparison_operators(connection, enum_schema, enum_type_name, temporary_enum_type_name)
         drop_type(connection, temporary_enum_type_name)
 
         recreate_indexes(connection, indexes_to_recreate)

--- a/alembic_postgresql_enum/sql_commands/comparison_operators.py
+++ b/alembic_postgresql_enum/sql_commands/comparison_operators.py
@@ -15,17 +15,20 @@ def _get_escaped_enum_type_name(enum_schema: str, enum_name: str):
 
 def _create_comparison_operator(
     connection: "Connection",
+    enum_schema: str,
     new_enum_type_name: str,
     old_enum_type_name: str,
     enum_values_to_rename: List[Tuple[str, str]],
     operator: str,
     comparison_function_name: str,
 ):
+    qualified_function_name = f'"{enum_schema}".{comparison_function_name}'
+    qualified_operator = f'"{enum_schema}".{operator}'
     if enum_values_to_rename:
         connection.execute(
             sqlalchemy.text(
                 f"""
-            CREATE FUNCTION {comparison_function_name}(
+            CREATE FUNCTION {qualified_function_name}(
                 new_enum_val {new_enum_type_name}, old_enum_val {old_enum_type_name}
             )
             RETURNS boolean AS $$
@@ -44,7 +47,7 @@ def _create_comparison_operator(
         connection.execute(
             sqlalchemy.text(
                 f"""
-            CREATE FUNCTION {comparison_function_name}(
+            CREATE FUNCTION {qualified_function_name}(
                 new_enum_val {new_enum_type_name}, old_enum_val {old_enum_type_name}
             )
             RETURNS boolean AS $$
@@ -56,10 +59,10 @@ def _create_comparison_operator(
     connection.execute(
         sqlalchemy.text(
             f"""
-        CREATE OPERATOR {operator} (
+        CREATE OPERATOR {qualified_operator} (
             leftarg = {new_enum_type_name},
             rightarg = {old_enum_type_name},
-            procedure = {comparison_function_name}
+            procedure = {qualified_function_name}
         )
     """
         )
@@ -68,6 +71,7 @@ def _create_comparison_operator(
 
 def create_comparison_operators(
     connection: "Connection",
+    enum_schema: str,
     enum_type_name: str,
     old_enum_type_name: str,
     enum_values_to_rename: List[Tuple[str, str]],
@@ -75,6 +79,7 @@ def create_comparison_operators(
     for operator, comparison_function_name in OPERATORS_TO_CREATE:
         _create_comparison_operator(
             connection,
+            enum_schema,
             enum_type_name,
             old_enum_type_name,
             enum_values_to_rename,
@@ -85,16 +90,19 @@ def create_comparison_operators(
 
 def _drop_comparison_operator(
     connection: "Connection",
+    enum_schema: str,
     new_enum_type_name: str,
     old_enum_type_name: str,
     comparison_function_name: str,
     operator_symbol: str,
 ):
+    qualified_function_name = f'"{enum_schema}".{comparison_function_name}'
+    qualified_operator = f'"{enum_schema}".{operator_symbol}'
     # First drop the operator that depends on the function
     connection.execute(
         sqlalchemy.text(
             f"""
-            DROP OPERATOR IF EXISTS {operator_symbol} (
+            DROP OPERATOR IF EXISTS {qualified_operator} (
                 {new_enum_type_name},
                 {old_enum_type_name}
             )
@@ -106,7 +114,7 @@ def _drop_comparison_operator(
     connection.execute(
         sqlalchemy.text(
             f"""
-        DROP FUNCTION {comparison_function_name}(
+        DROP FUNCTION {qualified_function_name}(
             new_enum_val {new_enum_type_name}, old_enum_val {old_enum_type_name}
         )
     """
@@ -116,10 +124,11 @@ def _drop_comparison_operator(
 
 def drop_comparison_operators(
     connection: "Connection",
+    enum_schema: str,
     enum_type_name: str,
     old_enum_type_name: str,
 ):
     for operator_symbol, comparison_function_name in OPERATORS_TO_CREATE:
         _drop_comparison_operator(
-            connection, enum_type_name, old_enum_type_name, comparison_function_name, operator_symbol
+            connection, enum_schema, enum_type_name, old_enum_type_name, comparison_function_name, operator_symbol
         )

--- a/tests/sync_enum_values/test_run_in_different_schema.py
+++ b/tests/sync_enum_values/test_run_in_different_schema.py
@@ -2,6 +2,7 @@
 import enum
 from typing import TYPE_CHECKING
 
+import sqlalchemy
 from alembic.operations import Operations
 from alembic.runtime.migration import MigrationContext
 
@@ -66,3 +67,158 @@ def test_run_in_different_schema(connection: "Connection"):
     defined = get_defined_enums(connection, DEFAULT_SCHEMA)
 
     assert defined == {"test_status": tuple(new_enum_variants)}
+
+
+def test_sync_enum_values_in_non_public_schema(connection: "Connection"):
+    """Comparison functions and operators should be created in the enum's schema,
+    not in the public schema. This matters when the migration user lacks CREATE
+    privileges on the public schema."""
+    connection.execute(sqlalchemy.text(
+        f'CREATE TYPE "{ANOTHER_SCHEMA_NAME}"."task_status" AS ENUM (\'pending\', \'running\', \'done\')'
+    ))
+    connection.execute(sqlalchemy.text(
+        f'CREATE TABLE "{ANOTHER_SCHEMA_NAME}"."tasks" ('
+        f'id serial PRIMARY KEY, '
+        f'status "{ANOTHER_SCHEMA_NAME}"."task_status" NOT NULL)'
+    ))
+
+    mc = MigrationContext.configure(connection)
+    ops = Operations(mc)
+
+    ops.sync_enum_values(
+        ANOTHER_SCHEMA_NAME,
+        "task_status",
+        ["pending", "running", "done", "failed"],
+        [
+            TableReference(
+                table_name="tasks",
+                column_name="status",
+                table_schema=ANOTHER_SCHEMA_NAME,
+            )
+        ],
+    )
+
+    defined = get_defined_enums(connection, ANOTHER_SCHEMA_NAME)
+    assert defined == {"task_status": ("pending", "running", "done", "failed")}
+
+
+def test_sync_enum_values_with_rename_in_non_public_schema(connection: "Connection"):
+    """Comparison functions and operators for renames should also be created
+    in the enum's schema."""
+    connection.execute(sqlalchemy.text(
+        f'CREATE TYPE "{ANOTHER_SCHEMA_NAME}"."color" AS ENUM (\'red\', \'green\', \'blue\')'
+    ))
+    connection.execute(sqlalchemy.text(
+        f'CREATE TABLE "{ANOTHER_SCHEMA_NAME}"."items" ('
+        f'id serial PRIMARY KEY, '
+        f'color "{ANOTHER_SCHEMA_NAME}"."color" NOT NULL)'
+    ))
+    connection.execute(sqlalchemy.text(
+        f'INSERT INTO "{ANOTHER_SCHEMA_NAME}"."items" (color) VALUES (\'red\'), (\'green\')'
+    ))
+
+    mc = MigrationContext.configure(connection)
+    ops = Operations(mc)
+
+    ops.sync_enum_values(
+        ANOTHER_SCHEMA_NAME,
+        "color",
+        ["red", "lime", "blue"],
+        [
+            TableReference(
+                table_name="items",
+                column_name="color",
+                table_schema=ANOTHER_SCHEMA_NAME,
+            )
+        ],
+        enum_values_to_rename=[("green", "lime")],
+    )
+
+    defined = get_defined_enums(connection, ANOTHER_SCHEMA_NAME)
+    assert defined == {"color": ("red", "lime", "blue")}
+
+    rows = connection.execute(sqlalchemy.text(
+        f'SELECT color FROM "{ANOTHER_SCHEMA_NAME}"."items" ORDER BY id'
+    )).scalars().all()
+    assert rows == ["red", "lime"]
+
+
+RESTRICTED_USER = "restricted_migration_user"
+
+
+def test_sync_enum_values_without_public_create_privilege(connection: "Connection"):
+    """When the migration user lacks CREATE on public, comparison functions
+    and operators must be created in the enum's own schema. Without
+    schema-qualification this test fails with 'permission denied for schema public'."""
+    # Create a restricted role that owns the 'another' schema but cannot create in public.
+    # Use SET LOCAL ROLE to assume its identity within this transaction.
+    connection.execute(sqlalchemy.text(
+        f"DROP ROLE IF EXISTS {RESTRICTED_USER}"
+    ))
+    connection.execute(sqlalchemy.text(
+        f"CREATE ROLE {RESTRICTED_USER} NOLOGIN"
+    ))
+    connection.execute(sqlalchemy.text(
+        f'ALTER SCHEMA "{ANOTHER_SCHEMA_NAME}" OWNER TO {RESTRICTED_USER}'
+    ))
+    connection.execute(sqlalchemy.text(
+        f"REVOKE CREATE ON SCHEMA public FROM {RESTRICTED_USER}"
+    ))
+    # Create enum and table owned by the restricted user
+    connection.execute(sqlalchemy.text(
+        f'CREATE TYPE "{ANOTHER_SCHEMA_NAME}"."priority" '
+        f"AS ENUM ('low', 'medium', 'high')"
+    ))
+    connection.execute(sqlalchemy.text(
+        f'ALTER TYPE "{ANOTHER_SCHEMA_NAME}"."priority" '
+        f"OWNER TO {RESTRICTED_USER}"
+    ))
+    connection.execute(sqlalchemy.text(
+        f'CREATE TABLE "{ANOTHER_SCHEMA_NAME}"."tickets" ('
+        f'id serial PRIMARY KEY, '
+        f'priority "{ANOTHER_SCHEMA_NAME}"."priority" NOT NULL)'
+    ))
+    connection.execute(sqlalchemy.text(
+        f'ALTER TABLE "{ANOTHER_SCHEMA_NAME}"."tickets" '
+        f"OWNER TO {RESTRICTED_USER}"
+    ))
+    connection.execute(sqlalchemy.text(
+        f'ALTER SEQUENCE "{ANOTHER_SCHEMA_NAME}"."tickets_id_seq" '
+        f"OWNER TO {RESTRICTED_USER}"
+    ))
+    connection.execute(sqlalchemy.text(
+        f'INSERT INTO "{ANOTHER_SCHEMA_NAME}"."tickets" (priority) '
+        f"VALUES ('low'), ('high')"
+    ))
+
+    # Switch to the restricted role — permission checks now apply
+    connection.execute(sqlalchemy.text(
+        f"SET LOCAL ROLE {RESTRICTED_USER}"
+    ))
+
+    mc = MigrationContext.configure(connection)
+    ops = Operations(mc)
+
+    ops.sync_enum_values(
+        ANOTHER_SCHEMA_NAME,
+        "priority",
+        ["low", "medium", "high", "critical"],
+        [
+            TableReference(
+                table_name="tickets",
+                column_name="priority",
+                table_schema=ANOTHER_SCHEMA_NAME,
+            )
+        ],
+    )
+
+    defined = get_defined_enums(connection, ANOTHER_SCHEMA_NAME)
+    assert defined == {"priority": ("low", "medium", "high", "critical")}
+
+    rows = connection.execute(sqlalchemy.text(
+        f'SELECT priority FROM "{ANOTHER_SCHEMA_NAME}"."tickets" ORDER BY id'
+    )).scalars().all()
+    assert rows == ["low", "high"]
+
+    # Restore original role
+    connection.execute(sqlalchemy.text("RESET ROLE"))


### PR DESCRIPTION
### Description

The library creates temporary comparison functions (new_old_equals, new_old_not_equals) and operators (=, !=) during enum value sync. Previously these were created with unqualified names, defaulting to the public schema. When the migration user lacks CREATE privileges on the public schema, this caused permission denied errors.

Now the functions and operators are created in the enum's own schema (e.g. "myschema".new_old_equals), which only requires privileges on the schema where the enum already lives.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
